### PR TITLE
fix: correct syntax in conversation message formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ convo = Conversation.from_messages([
     Message.from_role_and_content(
         Role.DEVELOPER,
         DeveloperContent.new().with_instructions("Talk like a pirate!")
-    )
+    ),
     Message.from_role_and_content(Role.USER, "Arrr, how be you?"),
 ])
 tokens = enc.render_conversation_for_completion(convo, Role.ASSISTANT)


### PR DESCRIPTION
### Summary
Fix a missing comma in the Python example in README that causes a SyntaxError.

### Changes
- add missing comma in README's Python example
- close #5 
