### PR TITLE
cross compile bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
 ] }
 futures = "0.3"
 clap = { version = "4", features = ["derive"] }
-pyo3 = { version = "0.25.0", optional = true, features = ["extension-module"] }
+pyo3 = { version = "0.25.0", optional = true, features = ["extension-module",  "abi3-py38"] }
 wasm-bindgen = { version = "0.2.100", optional = true, features = [
     "serde-serialize",
 ] }


### PR DESCRIPTION
Adds abi-py38 feature to compile to python3.8+. Fixed baseten's production. 

I am indifferent if this is merged, or if you merge it in another PR. Preferably, I would like to have a release on pypi asap.