### PR TITLE
Fix long sentence in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 <br>
 </center>
 
-The [gpt-oss models][gpt-oss] were trained on the [harmony response format][harmony-format] for defining conversation structures, generating reasoning output and structuring function calls. If you are not using gpt-oss directly but through an API or a provider like HuggingFace, Ollama, or vLLM, you will not have to be concerned about this as your inference solution will handle the formatting. If you are building your own inference solution, this guide will walk you through the prompt format. The format is designed to mimic the OpenAI Responses API, so if you have used that API before, this format should hopefully feel familiar to you. gpt-oss should not be used without using the harmony format as it will not work correctly.
+The [gpt-oss models][gpt-oss] were trained on the [harmony response format][harmony-format] for defining conversation structures, generating reasoning output and structuring function calls. If you are using gpt-oss directly, you need to use the harmony format. If you are building your own inference solution, this guide will walk you through the prompt format. If you are using an API or a provider like HuggingFace, Ollama, or vLLM, you do *not* need to worry about the format. 
+
+The format is designed to mimic the OpenAI Responses API, so if you have used that API before, this format should hopefully feel familiar to you. gpt-oss should not be used without using the harmony format as it will not work correctly.
 
 The format enables the model to output to multiple different channels for chain of thought, and tool calling preambles along with regular responses. It also enables specifying various tool namespaces, and structured outputs along with a clear instruction hierarchy. [Check out the guide][harmony-format] to learn more about the format itself.
 


### PR DESCRIPTION
The intro to readme.md contains a confusingly structured sentence.

> If you are not using gpt-oss directly but through an API or a provider like HuggingFace, Ollama, or vLLM, you will not have to be concerned about this as your inference solution will handle the formatting.

This PR splits it into two, avoids the "not using ... not have to be concerned" structure. 