### PR TITLE
fix: `meta_sep` token in `encoding.rs`

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -68,7 +68,7 @@ impl FormattingToken {
             FormattingToken::Channel => "<|channel|>",
             FormattingToken::BeginUntrusted => "<|untrusted|>",
             FormattingToken::EndUntrusted => "<|end_untrusted|>",
-            FormattingToken::MetaSep => "<|channel|>",
+            FormattingToken::MetaSep => "<|meta_sep|>",
             FormattingToken::MetaEnd => "<|meta_end|>",
         }
     }


### PR DESCRIPTION
Change:
- Corrected the MetaSep formatting token to map to `<|meta_sep|>` instead of the `channel` token mapping.