### PR TITLE
docs: fix typo in README.md ( - harmony -> - python/openai_harmony)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ through thin [`pyo3`](https://pyo3.rs/) bindings.
 │   ├── tests.rs          # Canonical Rust test-suite
 │   └── py_module.rs      # PyO3 bindings ⇒ compiled as openai_harmony.*.so
 │
-├── harmony/              # Pure-Python wrapper around the binding
+├── python/openai_harmony/ # Pure-Python wrapper around the binding
 │   └── __init__.py       # Dataclasses + helper API mirroring chat.rs
 │
 ├── tests/                # Python test-suite (1-to-1 port of tests.rs)

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -5,4 +5,5 @@ set -e
 cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all-targets --all-features
-
+mypy python/openai_harmony
+ruff check .

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -5,5 +5,4 @@ set -e
 cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all-targets --all-features
-mypy python/openai_harmony
-ruff check .
+


### PR DESCRIPTION
Fix REAMDE.md 'sfile structure naming.