### PR TITLE
fix race conditions and add offline tokenizer loading api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1334,7 @@ dependencies = [
  "bstr",
  "clap",
  "fancy-regex",
+ "fs2",
  "futures",
  "image",
  "pretty_assertions",
@@ -2555,6 +2566,28 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ wasm-binding = ["wasm-bindgen", "serde-wasm-bindgen", "wasm-bindgen-futures"]
 [dependencies]
 anyhow = "1.0.98"
 base64 = "0.22.1"
+fs2 = "0.4.3"
 image = "0.25.6"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }

--- a/python/openai_harmony/__init__.py
+++ b/python/openai_harmony/__init__.py
@@ -36,13 +36,10 @@ from pydantic import BaseModel, Field
 try:
     from .openai_harmony import (
         HarmonyError as HarmonyError,  # expose the actual Rust error directly
-    )
-    from .openai_harmony import PyHarmonyEncoding as _PyHarmonyEncoding  # type: ignore
-    from .openai_harmony import (
+        PyHarmonyEncoding as _PyHarmonyEncoding,  # type: ignore
         PyStreamableParser as _PyStreamableParser,  # type: ignore
-    )
-    from .openai_harmony import (
         load_harmony_encoding as _load_harmony_encoding,  # type: ignore
+        load_harmony_encoding_from_file as _load_harmony_encoding_from_file,  # type: ignore
     )
 
 except ModuleNotFoundError:  # pragma: no cover – raised during type-checking
@@ -690,6 +687,32 @@ def load_harmony_encoding(name: str | "HarmonyEncodingName") -> HarmonyEncoding:
     return HarmonyEncoding(inner)
 
 
+def load_harmony_encoding_from_file(
+    name: str,
+    vocab_file: str,
+    special_tokens: list[tuple[str, int]],
+    pattern: str,
+    n_ctx: int,
+    max_message_tokens: int,
+    max_action_length: int,
+    expected_hash: str | None = None,
+) -> HarmonyEncoding:
+    """Load a HarmonyEncoding from a local vocab file (offline usage).
+    Use this when network access is restricted or for reproducible builds where you want to avoid remote downloads.
+    """
+    inner: _PyHarmonyEncoding = _load_harmony_encoding_from_file(
+        name,
+        vocab_file,
+        special_tokens,
+        pattern,
+        n_ctx,
+        max_message_tokens,
+        max_action_length,
+        expected_hash,
+    )
+    return HarmonyEncoding(inner)
+
+
 # For *mypy* we expose a minimal stub of the `HarmonyEncodingName` enum.  At
 # **runtime** the user is expected to pass the *string* names because the Rust
 # side only operates on strings anyway.
@@ -718,4 +741,5 @@ __all__ = [
     "StreamableParser",
     "StreamState",
     "HarmonyError",
+    "load_harmony_encoding_from_file",
 ]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -154,6 +154,31 @@ impl HarmonyEncoding {
             })
             .collect()
     }
+
+    pub fn from_local_file(
+        name: String,
+        vocab_file: &std::path::Path,
+        expected_hash: Option<&str>,
+        special_tokens: impl IntoIterator<Item = (String, u32)>,
+        pattern: &str,
+        n_ctx: usize,
+        max_message_tokens: usize,
+        max_action_length: usize,
+    ) -> anyhow::Result<Self> {
+        use crate::tiktoken_ext::public_encodings::load_encoding_from_file;
+        let bpe = load_encoding_from_file(vocab_file, expected_hash, special_tokens, pattern)?;
+        Ok(HarmonyEncoding {
+            name,
+            n_ctx,
+            max_message_tokens,
+            max_action_length,
+            tokenizer_name: vocab_file.display().to_string(),
+            tokenizer: std::sync::Arc::new(bpe),
+            format_token_mapping: Default::default(),
+            stop_formatting_tokens: Default::default(),
+            stop_formatting_tokens_for_assistant_actions: Default::default(),
+        })
+    }
 }
 
 // Methods for rendering conversations

--- a/src/tiktoken_ext/mod.rs
+++ b/src/tiktoken_ext/mod.rs
@@ -1,2 +1,2 @@
-mod public_encodings;
+pub mod public_encodings;
 pub use public_encodings::{set_tiktoken_base_url, Encoding};


### PR DESCRIPTION
Resolved the race condition issue when multiple encoders are built in parallel (in #35). Added `load_harmony_encoding_from_file()` Python API for offline use. Also added some tests to make sure everything works smoothly.