### PR TITLE
Fix tokenization of <|constrain|> content type in rendering

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -835,7 +835,22 @@ impl Render<Message> for HarmonyEncoding {
 
         // finally content type
         if let Some(content_type) = &message.content_type {
-            self.render_text_into(format!(" {content_type}"), into)?;
+            // <|constrain|> is a unique case which needs to be tokenized as a special token
+            if let Some(constrain_marker) = self.mapped_format_token(FormattingToken::ConstrainedFormat) {
+                if content_type.starts_with(constrain_marker) {
+                    // Render the space, then the constrain marker as a special token, then the rest as text (if any)
+                    self.render_text_into(" ", into)?;
+                    self.render_formatting_token_into(FormattingToken::ConstrainedFormat, into)?;
+                    let rest = &content_type[constrain_marker.len()..];
+                    if !rest.is_empty() {
+                        self.render_text_into(rest, into)?;
+                    }
+                } else {
+                    self.render_text_into(format!(" {content_type}"), into)?;
+                }
+            } else {
+                self.render_text_into(format!(" {content_type}"), into)?;
+            }
         }
 
         self.render_formatting_token_into(FormattingToken::Message, into)?;


### PR DESCRIPTION
The recommended way to render a constrained JSON clause in Harmony is `.with_content_type("<|constrain|>json")`. Unfortunately, the current code treats it as user input and doesn't tokenize into special tokens.

Thus, the previous tool calls get rendered wrong into the token space by `encoding.render_conversation`:

```
From rendering =======
' <' '|' 'con' 'strain' '|' '>' 'json' '<|message|>' '{}' '<|call|>'

After re-encoding or as produced by model =======
' ' '<|constrain|>' 'json' '<|message|>' '{}' '<|call|>'
```

<img width="673" height="65" alt="image" src="https://github.com/user-attachments/assets/33d1491e-4176-48d5-bacc-bbf57f9621be" />

This confuses the model and leads to invalid syntax for subsequent tool calling, especially on 20B model. See https://github.com/openai/harmony/issues/27#issuecomment-3165293021 for more context

If one renders text and encodes it back with special tokens allowed, the output is fixed. However, it opens an opportunity for prompt injection attacks as user input may now contain special tokens.

Instead, this PR handles the `<|constrain|>` special case explicitly. Alternative would be to add explicit API like `.with_content_type("json", contrain=True)` but it feels like a bigger change.

## Minimal repro

<details>
<summary>Script</summary>

```
from openai_harmony import load_harmony_encoding, Conversation, Message, Role

encoding = load_harmony_encoding("HarmonyGptOss")

tool_call_message = (
    Message.from_role_and_content(Role.ASSISTANT, "{}")
    .with_recipient("functions.dummy")
    .with_channel("commentary")
    .with_content_type("<|constrain|>json")
)
conversation = Conversation.from_messages([tool_call_message])
tokens = encoding.render_conversation(conversation=conversation)
text = encoding.decode_utf8(tokens)
reencoded_tokens = encoding.encode(text, allowed_special="all")
text_reencoded = encoding.decode_utf8(reencoded_tokens)

print(f"{tokens == reencoded_tokens=}")
print(f"{text == text_reencoded=}")

print("text =======")
print(text)
print()
print("reencoded text =======")
print(text_reencoded)
print()

print("tokens =======")
print(" ".join([repr(encoding.decode([token])) for token in tokens]))
print()
print("reencoded tokens =======")
print(" ".join([repr(encoding.decode([token])) for token in reencoded_tokens]))
print()
```

</details>

### output before this PR

```
tokens == reencoded_tokens=False
text == text_reencoded=True
text =======
<|start|>assistant to=functions.dummy<|channel|>commentary <|constrain|>json<|message|>{}<|call|>

reencoded text =======
<|start|>assistant to=functions.dummy<|channel|>commentary <|constrain|>json<|message|>{}<|call|>

tokens =======
'<|start|>' 'assistant' ' to' '=' 'functions' '.d' 'ummy' '<|channel|>' 'comment' 'ary' ' <' '|' 'con' 'strain' '|' '>' 'json' '<|message|>' '{}' '<|call|>'

reencoded tokens =======
'<|start|>' 'assistant' ' to' '=' 'functions' '.d' 'ummy' '<|channel|>' 'comment' 'ary' ' ' '<|constrain|>' 'json' '<|message|>' '{}' '<|call|>'
```

### output after this PR

```
tokens == reencoded_tokens=True
text == text_reencoded=True
text =======
<|start|>assistant to=functions.dummy<|channel|>commentary <|constrain|>json<|message|>{}<|call|>

reencoded text =======
<|start|>assistant to=functions.dummy<|channel|>commentary <|constrain|>json<|message|>{}<|call|>

tokens =======
'<|start|>' 'assistant' ' to' '=' 'functions' '.d' 'ummy' '<|channel|>' 'comment' 'ary' ' ' '<|constrain|>' 'json' '<|message|>' '{}' '<|call|>'

reencoded tokens =======
'<|start|>' 'assistant' ' to' '=' 'functions' '.d' 'ummy' '<|channel|>' 'comment' 'ary' ' ' '<|constrain|>' 'json' '<|message|>' '{}' '<|call|>'
```