### PR TITLE
Add 'DeveloperContent' to __all__

### DIFF
--- a/python/openai_harmony/__init__.py
+++ b/python/openai_harmony/__init__.py
@@ -708,6 +708,7 @@ __all__ = [
     "Author",
     "Content",
     "TextContent",
+    "DeveloperContent",
     "ToolDescription",
     "SystemContent",
     "Message",


### PR DESCRIPTION
I had to do this to get the demo to work:

```python
uv run --python 3.12 --with openai-harmony python -c '
from openai_harmony import *
from openai_harmony import DeveloperContent
enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
convo = Conversation.from_messages([
    Message.from_role_and_content(
        Role.SYSTEM,
        SystemContent.new(),
    ),
    Message.from_role_and_content(
        Role.DEVELOPER,
        DeveloperContent.new().with_instructions("Talk like a pirate!")
    ),
    Message.from_role_and_content(Role.USER, "Arrr, how be you?"),
])
tokens = enc.render_conversation_for_completion(convo, Role.ASSISTANT)
print(tokens)'
```
With this change I'll be able to just use this:
```python
uv run --python 3.12 --with openai-harmony python -c '
from openai_harmony import *
enc = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
convo = Conversation.from_messages([
    Message.from_role_and_content(
        Role.SYSTEM,
        SystemContent.new(),
    ),
    Message.from_role_and_content(
        Role.DEVELOPER,
        DeveloperContent.new().with_instructions("Talk like a pirate!")
    ),
    Message.from_role_and_content(Role.USER, "Arrr, how be you?"),
])
tokens = enc.render_conversation_for_completion(convo, Role.ASSISTANT)
print(tokens)'
```