### PR TITLE
fix unexpected keyword argument render_options #52

### DIFF
--- a/python/openai_harmony/__init__.py
+++ b/python/openai_harmony/__init__.py
@@ -514,7 +514,7 @@ class HarmonyEncoding:
             }
 
         return self._inner.render(
-            message_json=message.to_json(), render_options=render_options_dict
+            message.to_json(), render_options_dict
         )
 
     # -- Parsing -------------------------------------------------------


### PR DESCRIPTION
The Python wrapper called the Rust binding with keyword arguments, but the Rust binding expected positional arguments. That's why #52 reported the call to `encoding.render(msg, render_options=...)`. So, I changed the Python method to pass positional arguments instead of keyword arguments when calling the binding.