### PR TITLE
add missing .with_recipient('assistant') to tool message in demo code #62

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -100,7 +100,9 @@ convo = Conversation.from_messages(
         Message.from_author_and_content(
             Author.new(Role.TOOL, "functions.lookup_weather"),
             '{ "temperature": 20, "sunny": true }',
-        ).with_channel("commentary"),
+        )
+        .with_channel("commentary")
+        .with_recipient("assistant"),
     ]
 )
 


### PR DESCRIPTION
The demo was missing the required `.with_recipient("assistant")` call on tool messages. We can see in harmony format specification that tool messages should include `to=assistant` in their header because the tool response requires the assistant to process. It's currently producing this format:
```
<|start|>functions.lookup_weather<|channel|>commentary<|message|>{ "temperature": 20, "sunny": true }<|end|>
```
Here's our format specification in harmony:
```
<|start|>{toolname} to=assistant<|channel|>commentary<|message|>{output}<|end|>
```

So with that we can correctly produce this:
```
<|start|>functions.lookup_weather to=assistant<|channel|>commentary<|message|>{ "temperature": 20, "sunny": true }<|end|>
```

The issue #62 suggested doing that and I also created a simple test that compared both situations. I found out that the original had 241 tokens, the update has 244 tokens now, the first difference found at token 221, and the decoded text showed the missing `to=assistant` part in the tool message header.

So now 3 additional tokens when `.with_recipient("assistant")` is added.

While I was probing into this issue, I also discovered that there's a separate test failure in `test_does_not_drop_if_ongoing_analysis` that appears to be related to tokenization differences in the `<|constrain|>json` part, but this is unrelated to the missing `.with_recipient("assistant")` issue and should be addressed separately.