### PR TITLE
fix: Resolve response format corruption due to incorrect encoding

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -820,6 +820,12 @@ impl Render<Message> for HarmonyEncoding {
             }
         };
 
+        // next header channel
+        if let Some(channel) = &message.channel {
+            self.render_formatting_token_into(FormattingToken::Channel, into)?;
+            self.render_text_into(channel, into)?;
+        }
+
         // next render the header recipient, if there is one
         if let Some(recipient) = &message.recipient {
             if recipient != "all" {
@@ -827,24 +833,15 @@ impl Render<Message> for HarmonyEncoding {
             }
         }
 
-        // next header channel
-        if let Some(channel) = &message.channel {
-            self.render_formatting_token_into(FormattingToken::Channel, into)?;
-            self.render_text_into(channel, into)?;
-        }
-
         // finally content type
         if let Some(content_type) = &message.content_type {
-            // <|constrain|> is a unique case which needs to be tokenized as a special token
             if let Some(constrain_marker) =
                 self.mapped_format_token(FormattingToken::ConstrainedFormat)
             {
                 if let Some(rest) = content_type.strip_prefix(constrain_marker) {
-                    // Render the space, then the constrain marker as a special token, then the rest as text (if any)
-                    self.render_text_into(" ", into)?;
-                    self.render_formatting_token_into(FormattingToken::ConstrainedFormat, into)?;
+                    // Render the content type with mandatory leading space
                     if !rest.is_empty() {
-                        self.render_text_into(rest, into)?;
+                        self.render_text_into(format!(" {rest}"), into)?;
                     }
                 } else {
                     self.render_text_into(format!(" {content_type}"), into)?;


### PR DESCRIPTION
I found the main encoding issues and the fixes are as follows:

1) 'to' and ' to' encoding issue 
There was an issue with incorrectly encoding the 'to' token (id 935) and ' to' token (id 316). During model training, it appears the model was configured to use id 316 when using tools, but when encoding produces 935 instead, there's a high probability the model will generate abnormal tokens. To resolve this, I modified it to consistently encode ' to'.

2) '<|constrain|>' encoding issue 
It appears that during model training, this token was not used, and instead tool execution requests were trained using the ' json' token with a space included, similar to the ' to' token. Therefore, I removed '<|constrain|>' and modified it to ensure spaces are mandatory. This solves the issue where including '<|constrain|>' makes the model's function output extremely unstable and generates abnormal tokens as tool executions are repeated multiple times.

Main token investigation details (token id):
220 = ' '
12606 = 'comment'
815 = 'ary'
316 = ' to' (presumed to be a token trained specifically for tool requests)
935 = 'to'
28 = '='
6961 = '??'
4108 = 'json'
5701 = ' json' (presumed to be a token trained specifically for tool requests)

openai/gpt-oss-20b

-------

For those using vllm, by applying the two additional PRs and using the model configuration values from the test code, you can use the tool execution functionality with almost 100% reliability without issues.

https://github.com/vllm-project/vllm/pull/24954
https://github.com/vllm-project/vllm/pull/24768