### PR TITLE
fix: handle malformed messages missing <|message|> token

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -107,8 +107,12 @@ convo = Conversation.from_messages(
 tokens = encoding.render_conversation_for_completion(convo, Role.ASSISTANT)
 
 # After receiving a token response
-# Do not pass in the stop token
-parsed_response = encoding.parse_messages_from_completion_tokens(new_tokens, Role.ASSISTANT)
+# Do not pass in the stop token. Set strict=False to tolerate malformed headers.
+parsed_response = encoding.parse_messages_from_completion_tokens(
+    new_tokens,
+    Role.ASSISTANT,
+    strict=True,
+)
 ```
 
 Additionally the openai_harmony library also includes a StreamableParser for parsing and decoding as the model is generating new tokens. This can be helpful for example to stream output and handle unicode characters during decoding.
@@ -269,7 +273,7 @@ If you are not using function tool calling your developer message would just loo
 
 Where `{instructions}` is replaced with your “system prompt”.
 
-For defining function calling tools, [check out the dedicated section](#function-calling).  
+For defining function calling tools, [check out the dedicated section](#function-calling).
 For defining an output format to be used in structured outputs, [check out this section of the guide](#structured-output).
 
 ### Reasoning
@@ -301,7 +305,7 @@ And the actual answer is:
 2 + 2 = 4
 ```
 
-**Important:**  
+**Important:**
 The model has not been trained to the same safety standards in the chain-of-thought as it has for final output. We recommend not to show the chain-of-thought to your users as they might contain harmful content. [Learn more in the model card](https://openai.com/index/gpt-oss-model-card/).
 
 #### Handling reasoning output in subsequent sampling

--- a/docs/python.md
+++ b/docs/python.md
@@ -107,12 +107,14 @@ Methods:
 - `render_conversation_for_training(conversation, config=None)` – render a conversation for training.
 - `render_conversation(conversation, config=None)` – render a conversation without appending a new role.
 - `render(message)` – render a single message into tokens.
-- `parse_messages_from_completion_tokens(tokens, role=None)` – parse tokens back into `Message` objects.
+- `parse_messages_from_completion_tokens(tokens, role=None, strict=True)` – parse tokens back into `Message` objects (set `strict=False` to enable permissive parsing).
 - `decode_utf8(tokens)` – decode tokens with the underlying tokenizer.
 - `stop_tokens()` / `stop_tokens_for_assistant_actions()` – lists of stop tokens.
 
+Use `strict=False` when you need the parser to recover from malformed model output that omits markers such as `<|message|>`.
+
 ### `StreamableParser`
-Incremental parser built on top of an encoding. Construct with `StreamableParser(encoding, role)` and feed tokens via `process(token)`.  Inspect state via properties like `current_content`, `current_role`, `tokens` and `state`.
+Incremental parser built on top of an encoding. Construct with `StreamableParser(encoding, role)` and feed tokens via `process(token)`.  Inspect state via properties like `current_content`, `current_role`, `tokens` and `state`. Pass `strict=False` to enable permissive parsing (mirrors `ParseOptions { strict: false }` on the Rust side).
 
 ### `load_harmony_encoding(name)`
 Return a `HarmonyEncoding` by name.  Accepts either the string name or a value from the `HarmonyEncodingName` enum (`HARMONY_GPT_OSS`).

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -88,12 +88,15 @@ Important methods:
 - `render_conversation_for_training(conversation, config)` – render a conversation for training data.
 - `render_conversation(conversation, config)` – render a conversation without appending a new role.
 - `render(message)` – render a single message into tokens.
-- `parse_messages_from_completion_tokens(tokens, role)` – parse a list of tokens back into messages.
+- `parse_messages_from_completion_tokens(tokens, role)` – parse a list of tokens back into messages using strict validation.
+- `parse_messages_from_completion_tokens_with_options(tokens, role, options)` – parse tokens with custom `ParseOptions` (e.g. to disable strict validation).
 - `stop_tokens()` and `stop_tokens_for_assistant_actions()` – sets of stop tokens for sampling.
+
+`ParseOptions` currently exposes a single field, `strict`, which defaults to `true`. Set it to `false` when you need to recover from malformed model output in downstream systems.
 
 ### `StreamableParser`
 
-Incremental parser that consumes tokens one by one. Create with `StreamableParser::new(encoding, role)` and feed tokens via `process`. Access information via getters like `current_content`, `current_role`, `messages`, `tokens` and `state_json`.
+Incremental parser that consumes tokens one by one. Create with `StreamableParser::new(encoding, role)` and feed tokens via `process`. Access information via getters like `current_content`, `current_role`, `messages`, `tokens` and `state_json`. Use `StreamableParser::new_with_options(encoding, role, options)` when you need to override defaults such as `ParseOptions { strict: false }`.
 
 ## registry module
 

--- a/python/openai_harmony/__init__.py
+++ b/python/openai_harmony/__init__.py
@@ -520,10 +520,14 @@ class HarmonyEncoding:
     # -- Parsing -------------------------------------------------------
 
     def parse_messages_from_completion_tokens(
-        self, tokens: Sequence[int], role: Optional[Role] | None = None
+        self,
+        tokens: Sequence[int],
+        role: Optional[Role] | None = None,
+        *,
+        strict: bool = True,
     ) -> List[Message]:
         raw_json: str = self._inner.parse_messages_from_completion_tokens(
-            list(tokens), None if role is None else str(role.value)
+            list(tokens), None if role is None else str(role.value), strict
         )
         return [Message.from_dict(m) for m in json.loads(raw_json)]
 
@@ -619,9 +623,15 @@ class StreamState(Enum):
 class StreamableParser:
     """Incremental parser over completion tokens."""
 
-    def __init__(self, encoding: HarmonyEncoding, role: Role | None):
+    def __init__(
+        self,
+        encoding: HarmonyEncoding,
+        role: Role | None,
+        *,
+        strict: bool = True,
+    ) -> None:
         role_str = str(role.value) if role is not None else None
-        self._inner = _PyStreamableParser(encoding._inner, role_str)
+        self._inner = _PyStreamableParser(encoding._inner, role_str, strict)
 
     def process(self, token: int) -> "StreamableParser":
         self._inner.process(token)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod registry;
 mod tiktoken;
 pub mod tiktoken_ext;
 
-pub use encoding::{HarmonyEncoding, StreamableParser};
+pub use encoding::{HarmonyEncoding, ParseOptions, StreamableParser};
 pub use registry::load_harmony_encoding;
 pub use registry::HarmonyEncodingName;
 

--- a/tests/test_harmony.py
+++ b/tests/test_harmony.py
@@ -983,7 +983,8 @@ def test_streamable_parser_tool_call_with_constrain_adjacent():
     assert parser.messages == expected
 
 
-def test_streamable_parser_missing_message_token():
+@pytest.mark.parametrize("strict, expect_error", [(False, False), (True, True)])
+def test_streamable_parser_missing_message_token(strict: bool, expect_error: bool):
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 
     text = (
@@ -992,7 +993,14 @@ def test_streamable_parser_missing_message_token():
         "<|start|>assistant<|channel|>final<|message|>I'm sorry, but I can't help with that.<|return|>"
     )
     tokens = encoding.encode(text, allowed_special="all")
-    parser = StreamableParser(encoding, Role.ASSISTANT)
+    parser = StreamableParser(encoding, Role.ASSISTANT, strict=strict)
+
+    if expect_error:
+        with pytest.raises(HarmonyError, match="unexpected tokens remaining in message header"):
+            for token in tokens:
+                parser.process(token)
+        return
+
     for token in tokens:
         parser.process(token)
 
@@ -1008,7 +1016,10 @@ def test_streamable_parser_missing_message_token():
     assert parser.messages == expected
 
 
-def test_streamable_parser_missing_message_token_other_initial_headers():
+@pytest.mark.parametrize("strict, expect_error", [(False, False), (True, True)])
+def test_streamable_parser_missing_message_token_other_initial_headers(
+    strict: bool, expect_error: bool
+):
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 
     text = (
@@ -1017,7 +1028,14 @@ def test_streamable_parser_missing_message_token_other_initial_headers():
         "<|start|>assistant<|channel|>final<|message|>I'm sorry, but I can't help with that.<|return|>"
     )
     tokens = encoding.encode(text, allowed_special="all")
-    parser = StreamableParser(encoding, Role.ASSISTANT)
+    parser = StreamableParser(encoding, Role.ASSISTANT, strict=strict)
+
+    if expect_error:
+        with pytest.raises(HarmonyError, match="unexpected tokens remaining in message header"):
+            for token in tokens:
+                parser.process(token)
+        return
+
     for token in tokens:
         parser.process(token)
 
@@ -1035,7 +1053,10 @@ def test_streamable_parser_missing_message_token_other_initial_headers():
     assert parser.messages == expected
 
 
-def test_streamable_parser_missing_message_token_tool_call():
+@pytest.mark.parametrize("strict, expect_error", [(False, False), (True, True)])
+def test_streamable_parser_missing_message_token_tool_call(
+    strict: bool, expect_error: bool
+):
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 
     text = (
@@ -1044,7 +1065,14 @@ def test_streamable_parser_missing_message_token_tool_call():
         '<|message|>{"location": "Tokyo"}<|call|>'
     )
     tokens = encoding.encode(text, allowed_special="all")
-    parser = StreamableParser(encoding, Role.ASSISTANT)
+    parser = StreamableParser(encoding, Role.ASSISTANT, strict=strict)
+
+    if expect_error:
+        with pytest.raises(HarmonyError, match="unexpected tokens remaining in message header"):
+            for token in tokens:
+                parser.process(token)
+        return
+
     for token in tokens:
         parser.process(token)
 


### PR DESCRIPTION
StreamableParser now gracefully handles LLM output where stop tokens appear before the expected <|message|> token. The parser extracts header metadata (channel, recipient, content_type) from accumulated tokens and treats the remainder as message content.

Refactors header parsing into a shared helper to eliminate duplication.