### PR TITLE
Strip duplicate channel markers from message headers

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1329,7 +1329,7 @@ impl StreamableParser {
     /// If `parse_recipient_and_type` is true, tries to parse recipient and content_type from
     /// whitespace-separated tokens (normal header parsing). If false, treats all remaining
     /// text after extracting channel as content (for malformed messages).
-    fn parse_header_from_string(
+    pub(crate) fn parse_header_from_string(
         &self,
         mut header_string: String,
         role: Option<Role>,
@@ -1352,6 +1352,19 @@ impl StreamableParser {
                 new_header.push_str(&header_string[..idx]);
                 new_header.push_str(&after_marker[channel_end..]);
                 header_string = new_header;
+
+                // Trim extraneous channel markers, which are sometimes emittted
+                // with smaller models in multi-turn conversations
+                while let Some(extra_idx) = header_string.find(channel_marker) {
+                    let after = &header_string[extra_idx + channel_marker.len()..];
+                    let end = after
+                        .find(|c: char| c.is_whitespace() || c == '<')
+                        .unwrap_or(after.len());
+                    let mut cleaned = String::new();
+                    cleaned.push_str(&header_string[..extra_idx]);
+                    cleaned.push_str(&after[end..]);
+                    header_string = cleaned;
+                }
             }
         }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -652,6 +652,10 @@ fn assert_tokens_eq(tokenizer: &CoreBPE, expected: &[Rank], actual: &[Rank]) {
     }
 }
 
+fn parsed_header_to_json(header: &crate::encoding::ParsedHeader) -> serde_json::Value {
+    serde_json::to_value(header).expect("ParsedHeader should be JSON-serializable")
+}
+
 #[test]
 fn test_streamable_parser_tool_call_with_constrain_adjacent() {
     let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
@@ -672,6 +676,131 @@ fn test_streamable_parser_tool_call_with_constrain_adjacent() {
         .with_content_type("<|constrain|>json"),
         parser.messages()[0]
     );
+}
+
+#[test]
+fn test_parse_header_from_string_extracts_channel_recipient_content_type() {
+    let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+    let parser = StreamableParser::new(encoding, None).unwrap();
+    let header_string =
+        "assistant<|channel|>commentary to=functions.get_weather <|constrain|>json".to_string();
+
+    let (header, remaining) = parser
+        .parse_header_from_string(header_string, None, true)
+        .unwrap();
+
+    assert_eq!(
+        parsed_header_to_json(&header),
+        json!({
+            "author": { "role": "assistant" },
+            "recipient": "functions.get_weather",
+            "channel": "commentary",
+            "content_type": "<|constrain|>json",
+        })
+    );
+    assert_eq!(remaining, None);
+}
+
+#[test]
+fn test_parse_header_from_string_extracts_channel_recipient_content_type_extra_channel() {
+    let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+    let parser = StreamableParser::new(encoding, None).unwrap();
+    let header_string =
+        "assistant<|channel|>commentary to=functions.get_weather<|channel|>commentary <|constrain|>json".to_string();
+
+    let (header, remaining) = parser
+        .parse_header_from_string(header_string, None, true)
+        .unwrap();
+
+    assert_eq!(
+        parsed_header_to_json(&header),
+        json!({
+            "author": { "role": "assistant" },
+            "recipient": "functions.get_weather",
+            "channel": "commentary",
+            "content_type": "<|constrain|>json",
+        })
+    );
+    assert_eq!(remaining, None);
+}
+
+#[test]
+fn test_parse_header_from_string_extracts_channel_recipient_content_type_extra_channels() {
+    let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+    let parser = StreamableParser::new(encoding, None).unwrap();
+    let header_string =
+        "assistant<|channel|>commentary to=functions.get_weather<|channel|>analysis <|channel|>commentary <|channel|>final".to_string();
+
+    let (header, remaining) = parser
+        .parse_header_from_string(header_string, None, true)
+        .unwrap();
+
+    assert_eq!(
+        parsed_header_to_json(&header),
+        json!({
+            "author": { "role": "assistant" },
+            "recipient": "functions.get_weather",
+            "channel": "commentary",
+            "content_type": null,
+        })
+    );
+    assert_eq!(remaining, None);
+}
+
+#[test]
+fn test_parse_header_from_string_channel_marker_without_value_errors() {
+    let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+    let parser = StreamableParser::new(encoding, None).unwrap();
+    let header_string = "assistant<|channel|> to=foo".to_string();
+
+    let result = parser.parse_header_from_string(header_string, None, true);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_parse_header_from_string_extra_channel_no_recipient() {
+    let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+    let parser = StreamableParser::new(encoding, None).unwrap();
+    let header_string = "assistant<|channel|>commentary<|channel|>analysis".to_string();
+
+    let (header, remaining) = parser
+        .parse_header_from_string(header_string, None, true)
+        .unwrap();
+
+    assert_eq!(
+        parsed_header_to_json(&header),
+        json!({
+            "author": { "role": "assistant" },
+            "recipient": null,
+            "channel": "commentary",
+            "content_type": null,
+        })
+    );
+    assert_eq!(remaining, None);
+}
+
+#[test]
+fn test_parse_header_from_string_extra_channel_adjacent_to_constrain() {
+    let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+    let parser = StreamableParser::new(encoding, None).unwrap();
+    let header_string =
+        "assistant<|channel|>commentary to=foo<|channel|>analysis<|constrain|>json".to_string();
+
+    let (header, remaining) = parser
+        .parse_header_from_string(header_string, None, true)
+        .unwrap();
+
+    assert_eq!(
+        parsed_header_to_json(&header),
+        json!({
+            "author": { "role": "assistant" },
+            "recipient": "foo",
+            "channel": "commentary",
+            "content_type": "<|constrain|>json",
+        })
+    );
+    assert_eq!(remaining, None);
 }
 
 #[test]


### PR DESCRIPTION
gpt-oss models occasionally emit extra `<|channel|>` markers in message headers during deep multi-turn conversations. Instead of erroring, the parser now strips all duplicate channel markers after extracting the first one, using the same boundary logic (stop at whitespace or '<') that is used when extracting the first channel marker.

This also marks `parse_header_from_string` as `pub(crate)` to allow for direct unit testing, and adds tests of the previous and new behavior to make sure that channels are extracted properly.


I have personally observed this in multiple real-world scenarios with vLLM and gpt-oss-20b specifically. gpt-oss-120b appears far less prone to this type of failure in following its format. See https://github.com/vllm-project/vllm/issues/32587 and https://github.com/vllm-project/vllm/pull/31677 for vLLM community reports of this as well.



This still takes the first channel marker in the header as before. Any subsequent ones are dropped vs replacing the first we saw. This was preferred to throwing an error because in the vLLM code paths here we're handling the models generated response so anything we can clean up or fix in real-world inference scenarios without ambiguity or loss seem like easy wins to improve the reliability of the models in the wild.