### PR TITLE
Add riscv64, make Linux targets more explicit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,9 @@ jobs:
           - runner: ubuntu-22.04
             target: powerpc64le-unknown-linux-gnu
             arch: ppc64le
+          - runner: ubuntu-22.04
+            target: riscv64gc-unknown-linux-gnu
+            arch: riscv64
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,15 +42,20 @@ jobs:
       matrix:
         platform:
           - runner: ubuntu-22.04
-            target: x86_64
+            target: x86_64-unknown-linux-gnu
+            arch: x86_64
           - runner: ubuntu-22.04
-            target: x86
+            target: i686-unknown-linux-gnu
+            arch: x86
           - runner: ubuntu-22.04
-            target: aarch64
+            target: aarch64-unknown-linux-gnu
+            arch: aarch64
           - runner: ubuntu-22.04
-            target: armv7
+            target: armv7-unknown-linux-gnueabihf
+            arch: armv7
           - runner: ubuntu-22.04
-            target: ppc64le
+            target: powerpc64le-unknown-linux-gnu
+            arch: ppc64le
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -70,7 +75,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
 
   musllinux:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,9 @@ jobs:
           - runner: ubuntu-22.04
             target: powerpc64le-unknown-linux-gnu
             arch: ppc64le
+          - runner: ubuntu-22.04
+            target: riscv64gc-unknown-linux-gnu
+            arch: riscv64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,15 +42,20 @@ jobs:
       matrix:
         platform:
           - runner: ubuntu-22.04
-            target: x86_64
+            target: x86_64-unknown-linux-gnu
+            arch: x86_64
           - runner: ubuntu-22.04
-            target: x86
+            target: i686-unknown-linux-gnu
+            arch: x86
           - runner: ubuntu-22.04
-            target: aarch64
+            target: aarch64-unknown-linux-gnu
+            arch: aarch64
           - runner: ubuntu-22.04
-            target: armv7
+            target: armv7-unknown-linux-gnueabihf
+            arch: armv7
           - runner: ubuntu-22.04
-            target: ppc64le
+            target: powerpc64le-unknown-linux-gnu
+            arch: ppc64le
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -70,7 +75,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
 
   musllinux:


### PR DESCRIPTION
maturin supports riscv64 (specifically, riscv64gc) as a target. Add that to the build matrix. Note that this inspires the previous commit to make things more explicit, as 'riscv64' is not a valid shorthand for the rustc target, but it is used in package names when uploaded to PyPI.

Note that this is being done on behalf of the [RISE Project](https://riseproject.dev/) to improve Python ecosystem support on riscv64 platforms.