### PR TITLE
ci: add riscv64 target to linux wheel build matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,8 @@ jobs:
             target: armv7
           - runner: ubuntu-22.04
             target: ppc64le
+          - runner: ubuntu-22.04
+            target: riscv64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Add `riscv64` to the maturin-action linux build matrix so that `linux_riscv64` wheels are built and published to PyPI.

maturin-action cross-compiles via `riscv64gc-unknown-linux-gnu` cargo target — no QEMU or additional infrastructure needed.

## Evidence

- Tested wheel: [`openai_harmony-0.0.8-cp38-abi3-manylinux_2_34_riscv64.whl`](https://github.com/gounthar/riscv64-python-wheels/releases/download/v2026.03.11-cp313/openai_harmony-0.0.8-cp38-abi3-manylinux_2_34_riscv64.whl)
- Built natively on BananaPi F3 (SpacemiT K1, rv64imafdcv, 8 cores @ 1.6 GHz)
- Build time: ~3 min
- Imports and passes basic smoke test on riscv64

## Context

- `riscv64gc-unknown-linux-gnu` is a Rust tier-2 target with std available
- maturin-action handles cross-compilation transparently
- RISC-V hardware is shipping (SiFive, SpacemiT, Sophgo SG2044)

Fixes #102

---

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms. Native riscv64 CI runners are available for free via [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners).