### PR TITLE
Fix warning about conflicting with the protected model_ namespace

### DIFF
--- a/python/openai_harmony/__init__.py
+++ b/python/openai_harmony/__init__.py
@@ -29,7 +29,7 @@ from typing import (
 )
 
 import re
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, DictConfig, Field
 
 # Re-export the low-level Rust bindings under a private name so that we can
 # keep the *public* namespace clean and purely Pythonic.
@@ -179,6 +179,7 @@ class ToolNamespaceConfig(BaseModel):
 
 
 class SystemContent(Content):
+    model_config = ConfigDict(protected_namespaces=("model_validate", "model_dump"))
     model_identity: Optional[str] = (
         "You are ChatGPT, a large language model trained by OpenAI."
     )


### PR DESCRIPTION
model_identity causes a warning to be emitted when this module is imported which is unkind.

```
.venv/lib/python3.12/site-packages/pydantic/_internal/_fields.py:132
  /home/jkessinger/repos/yolo/.venv/lib/python3.12/site-packages/pydantic/_internal/_fields.py:132: UserWarning: Field "model_identity" in SystemContent has conflict with protected namespace "model_".
  
  You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
    warnings.warn(
```