### PR TITLE
Fix Message pydantic serialization dropping content fields

### DIFF
--- a/python/openai_harmony/__init__.py
+++ b/python/openai_harmony/__init__.py
@@ -16,6 +16,7 @@ import json
 from enum import Enum
 from typing import (
     AbstractSet,
+    Annotated,
     Any,
     Collection,
     Dict,
@@ -121,6 +122,7 @@ class Content(BaseModel):  # noqa: D101 – simple wrapper
 
 
 class TextContent(Content):
+    type: Literal["text"] = "text"
     text: str
 
     def to_dict(self) -> Dict[str, Any]:
@@ -179,6 +181,7 @@ class ToolNamespaceConfig(BaseModel):
 
 
 class SystemContent(Content):
+    type: Literal["system_content"] = "system_content"
     model_identity: Optional[str] = (
         "You are ChatGPT, a large language model trained by OpenAI."
     )
@@ -249,6 +252,7 @@ class SystemContent(Content):
 
 
 class DeveloperContent(Content):
+    type: Literal["developer_content"] = "developer_content"
     instructions: Optional[str] = None
     tools: Optional[dict[str, ToolNamespaceConfig]] = None
 
@@ -283,12 +287,24 @@ class DeveloperContent(Content):
         return cls(**raw)
 
 
+# A tagged union over the concrete ``Content`` variants. Typing ``Message.content``
+# with this (instead of the bare ``Content`` base class) makes the standard pydantic
+# ``model_dump``/``model_dump_json`` emit each item's own fields, and lets
+# ``model_validate``/``model_validate_json`` rebuild the right subclass. Without it a
+# ``Content`` item serialises as ``{}`` because the base class declares no fields
+# (see https://github.com/openai/harmony/issues/78).
+AnyContent = Annotated[
+    Union[TextContent, SystemContent, DeveloperContent],
+    Field(discriminator="type"),
+]
+
+
 # Message & Conversation -----------------------------------------------------
 
 
 class Message(BaseModel):
     author: Author
-    content: List[Content] = Field(default_factory=list)
+    content: List[AnyContent] = Field(default_factory=list)
     channel: Optional[str] = None
     recipient: Optional[str] = None
     content_type: Optional[str] = None

--- a/tests/test_harmony.py
+++ b/tests/test_harmony.py
@@ -33,6 +33,7 @@ from openai_harmony import (  # noqa: E402
     Role,
     StreamableParser,
     SystemContent,
+    TextContent,
     ToolDescription,
     load_harmony_encoding,
 )
@@ -1244,3 +1245,50 @@ def test_streamable_parser_tricky_utf8_decoding():
 
     # Ensure if we're accumulating content deltas we still get the full utf-8 text
     assert "".join(content_deltas) == tricky_utf8_text
+
+
+def test_message_pydantic_serialization_preserves_content():
+    # Regression test for https://github.com/openai/harmony/issues/78
+    # ``Message.content`` is a list of ``Content`` subclasses, so the standard
+    # pydantic ``model_dump``/``model_dump_json`` used to drop the subclass fields
+    # and emit ``{}`` for each content item.
+    message = Message.from_role_and_content(
+        Role.ASSISTANT, "We respond politely."
+    ).with_channel("analysis")
+
+    dumped = message.model_dump()
+    assert dumped["content"] == [{"type": "text", "text": "We respond politely."}]
+    # The native dump now matches the bespoke ``to_dict`` helper.
+    assert dumped["content"] == message.to_dict()["content"]
+
+    # ``model_dump_json`` round-trips back to an equal object, reconstructing the
+    # concrete ``TextContent`` subclass via the ``type`` discriminator.
+    restored = Message.model_validate_json(message.model_dump_json())
+    assert isinstance(restored.content[0], TextContent)
+    assert restored == message
+
+
+def test_message_pydantic_serialization_system_and_developer_content():
+    # The discriminated union also covers the structured content variants.
+    system = Message.from_role_and_content(
+        Role.SYSTEM,
+        SystemContent.new().with_knowledge_cutoff("2024-06"),
+    )
+    developer = Message.from_role_and_content(
+        Role.DEVELOPER,
+        DeveloperContent.new().with_instructions("Talk like a pirate!"),
+    )
+
+    system_content = system.model_dump()["content"][0]
+    assert system_content["type"] == "system_content"
+    assert system_content["knowledge_cutoff"] == "2024-06"
+
+    developer_content = developer.model_dump()["content"][0]
+    assert developer_content["type"] == "developer_content"
+    assert developer_content["instructions"] == "Talk like a pirate!"
+
+    conversation = Conversation.from_messages([system, developer])
+    restored = Conversation.model_validate_json(conversation.model_dump_json())
+    assert isinstance(restored.messages[0].content[0], SystemContent)
+    assert isinstance(restored.messages[1].content[0], DeveloperContent)
+    assert restored == conversation


### PR DESCRIPTION
Fixes #78

## Problem

`Message.content` is typed as `List[Content]`, the base class. The base `Content` model declares no fields, so pydantic serializes each content item using the declared base type and emits `{}`, dropping `text` and the other subclass fields:

```python
>>> m = Message.from_role_and_content(Role.ASSISTANT, "hello").with_channel("analysis")
>>> m.model_dump_json()
{"author":{"role":"assistant","name":null},"content":[{}],"channel":"analysis",...}
```

This is what the issue (and the linked vLLM workaround in vllm-project/vllm#26185) runs into when serializing parser output, for example to send messages over SSE.

## Fix

Type `content` as a discriminated union of the concrete variants (`TextContent`, `SystemContent`, `DeveloperContent`) keyed on a new `type` literal field on each subclass. With this:

- `model_dump` / `model_dump_json` emit each item using its concrete runtime type, so the fields are preserved.
- `model_validate` / `model_validate_json` rebuild the correct subclass from the `type` discriminator, so a serialize/deserialize round trip returns an equal object.

The `type` values (`text`, `system_content`, `developer_content`) match what the existing `to_dict()` helpers already emit, so the bespoke `to_dict`/`to_json`/`from_dict` paths and the Rust interop are unchanged. After the fix the native dump and `to_dict()` agree:

```python
>>> m.model_dump_json()
{"author":{"role":"assistant","name":null},"content":[{"type":"text","text":"hello"}],"channel":"analysis",...}
>>> Message.model_validate_json(m.model_dump_json()) == m
True
```

## Testing

`pytest` passes (44 tests, including 2 new regression tests covering text, system, and developer content round-trips). Built locally with `maturin develop --release` on macOS, Python 3.14, pydantic 2.12.