### PR TITLE
fix: return a recoverable error instead of panicking on pathological tokenizer input

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -367,7 +367,7 @@ impl HarmonyEncoding {
         T: AsRef<str>,
         B: Extend<Rank>,
     {
-        into.extend(self.tokenizer.encode_ordinary(text.as_ref()));
+        into.extend(self.tokenizer.encode_ordinary(text.as_ref())?);
         Ok(())
     }
 

--- a/src/py_module.rs
+++ b/src/py_module.rs
@@ -264,7 +264,12 @@ impl PyHarmonyEncoding {
         };
         let allowed_set: std::collections::HashSet<&str> =
             allowed_vec.iter().map(|s| s.as_str()).collect();
-        Ok(self.inner.tokenizer().encode(text, &allowed_set).0)
+        let (tokens, _) = self
+            .inner
+            .tokenizer()
+            .encode(text, &allowed_set)
+            .map_err(|e| PyErr::new::<HarmonyError, _>(e.to_string()))?;
+        Ok(tokens)
     }
 
     /// Return the list of special tokens for this tokenizer.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -43,6 +43,7 @@ fn test_simple_convo() {
                 load_test_data("../test-data/test_simple_convo.txt").as_str(),
                 &encoding.tokenizer.special_tokens(),
             )
+            .unwrap()
             .0;
         let convo = Conversation::from_messages([
             Message::from_role_and_content(
@@ -101,6 +102,7 @@ fn test_simple_convo_with_effort() {
             let expected_tokens = encoding
                 .tokenizer
                 .encode(expected_text.as_str(), &encoding.tokenizer.special_tokens())
+                .unwrap()
                 .0;
             let sys = SystemContent::new()
                 .with_model_identity("You are ChatGPT, a large language model trained by OpenAI.")
@@ -195,6 +197,7 @@ fn test_reasoning_system_message() {
                 load_test_data("../test-data/test_reasoning_system_message.txt").as_str(),
                 &encoding.tokenizer.special_tokens(),
             )
+            .unwrap()
             .0;
         let convo = Conversation::from_messages([
             Message::from_role_and_content(
@@ -227,6 +230,7 @@ fn test_reasoning_system_message_no_instruction() {
                     .as_str(),
                 &encoding.tokenizer.special_tokens(),
             )
+            .unwrap()
             .0;
         let convo = Conversation::from_messages([
             Message::from_role_and_content(
@@ -261,6 +265,7 @@ fn test_reasoning_system_message_with_dates() {
                     .as_str(),
                 &encoding.tokenizer.special_tokens(),
             )
+            .unwrap()
             .0;
         let convo = Conversation::from_messages([
             Message::from_role_and_content(
@@ -548,6 +553,7 @@ fn test_tool_response_parsing() {
     let tokens = encoding
         .tokenizer
         .encode(&text_tokens, &encoding.tokenizer.special_tokens())
+        .unwrap()
         .0;
 
     let expected_message = Message::from_author_and_content(
@@ -575,6 +581,7 @@ fn test_encode_decode_roundtrip() {
     let tokens = encoding
         .tokenizer
         .encode(text, &std::collections::HashSet::new())
+        .unwrap()
         .0;
     assert_eq!(encoding.tokenizer.decode_utf8(&tokens).unwrap(), text);
 }
@@ -584,27 +591,46 @@ fn test_encode_allowed_special() {
     use std::collections::HashSet;
     let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
     let text = "hello world";
-    let tokens = encoding.tokenizer.encode(text, &HashSet::new()).0;
+    let tokens = encoding.tokenizer.encode(text, &HashSet::new()).unwrap().0;
     assert_eq!(tokens, vec![24912, 2375]);
     // Allowed special token
     let mut allowed = HashSet::new();
     allowed.insert("<|start|>");
-    let tokens = encoding.tokenizer.encode("<|start|>", &allowed).0;
+    let tokens = encoding.tokenizer.encode("<|start|>", &allowed).unwrap().0;
     assert_eq!(tokens, vec![200006]);
     // Allowed special = all
     allowed = encoding.tokenizer.special_tokens(); // set of all special tokens
-    let tokens = encoding.tokenizer.encode("<|start|>", &allowed).0;
+    let tokens = encoding.tokenizer.encode("<|start|>", &allowed).unwrap().0;
     assert_eq!(tokens, vec![200006]);
     // Disallowed special (should error)
-    let result = encoding.tokenizer.encode("<|start|>", &HashSet::new());
+    let result = encoding
+        .tokenizer
+        .encode("<|start|>", &HashSet::new())
+        .unwrap();
     assert!(
         result.0.is_empty() || result.0 != vec![200006],
         "Expected error or not special token for disallowed special token"
     );
     // Disallowed special = empty (should not treat as special)
-    let tokens = encoding.tokenizer.encode("<|start|>", &HashSet::new()).0;
+    let tokens = encoding
+        .tokenizer
+        .encode("<|start|>", &HashSet::new())
+        .unwrap()
+        .0;
     // This may not match the Python fallback, but should not be the special token
     assert_ne!(tokens, vec![200006]);
+}
+
+#[test]
+fn test_encode_pathological_input_returns_error_instead_of_panicking() {
+    use std::collections::HashSet;
+    let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+    // A very long run of the same character makes the fancy-regex backtracking
+    // engine give up with a recoverable error. Encoding must surface that as an
+    // `Err` rather than panicking and taking down the host process (see #93).
+    let text = "a".repeat(1_300_000);
+    assert!(encoding.tokenizer.encode(&text, &HashSet::new()).is_err());
+    assert!(encoding.tokenizer.encode_ordinary(&text).is_err());
 }
 
 #[test]
@@ -630,6 +656,7 @@ fn test_streamable_parser() {
     let tokens = encoding
         .tokenizer
         .encode(&text, &encoding.tokenizer.special_tokens())
+        .unwrap()
         .0;
     let mut parser =
         crate::encoding::StreamableParser::new(encoding.clone(), Some(Role::Assistant)).unwrap();
@@ -838,7 +865,11 @@ fn test_streamable_parser_waits_for_multi_token_utf8_sequence() {
         parser.process(*token).unwrap();
     }
 
-    let emoji_tokens = encoding.tokenizer().encode("💖", &HashSet::new()).0;
+    let emoji_tokens = encoding
+        .tokenizer()
+        .encode("💖", &HashSet::new())
+        .unwrap()
+        .0;
     assert!(
         emoji_tokens.len() >= 2,
         "expected multi-token emoji encoding"

--- a/src/tiktoken.rs
+++ b/src/tiktoken.rs
@@ -158,6 +158,19 @@ impl std::fmt::Display for DecodeError {
 
 impl std::error::Error for DecodeError {}
 
+#[derive(Debug, Clone)]
+pub struct EncodeError {
+    pub message: String,
+}
+
+impl std::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Could not encode text: {}", self.message)
+    }
+}
+
+impl std::error::Error for EncodeError {}
+
 const MAX_NUM_THREADS: usize = 128;
 
 #[derive(Clone)]
@@ -218,22 +231,29 @@ impl CoreBPE {
         })
     }
 
-    pub fn encode_ordinary(&self, text: &str) -> Vec<Rank> {
+    pub fn encode_ordinary(&self, text: &str) -> Result<Vec<Rank>, EncodeError> {
         // This is the core of the encoding logic; the other functions in here
         // just make things complicated :-)
         let regex = self._get_tl_regex();
         let mut ret = vec![];
         for mat in regex.find_iter(text) {
-            let piece = mat.unwrap().as_str().as_bytes();
+            let mat = mat.map_err(|e| EncodeError {
+                message: format!("Regex error while tokenizing: {e}"),
+            })?;
+            let piece = mat.as_str().as_bytes();
             match self.encoder.get(piece) {
                 Some(token) => ret.push(*token),
                 None => ret.extend(&byte_pair_encode(piece, &self.encoder)),
             }
         }
-        ret
+        Ok(ret)
     }
 
-    pub fn encode(&self, text: &str, allowed_special: &HashSet<&str>) -> (Vec<Rank>, usize) {
+    pub fn encode(
+        &self,
+        text: &str,
+        allowed_special: &HashSet<&str>,
+    ) -> Result<(Vec<Rank>, usize), EncodeError> {
         let special_regex = self._get_tl_special_regex();
         let regex = self._get_tl_regex();
         let mut ret = vec![];
@@ -245,7 +265,12 @@ impl CoreBPE {
             let mut start_find = start;
             loop {
                 // Find the next allowed special token, if any
-                next_special = special_regex.find_from_pos(text, start_find).unwrap();
+                next_special =
+                    special_regex
+                        .find_from_pos(text, start_find)
+                        .map_err(|e| EncodeError {
+                            message: format!("Regex error while tokenizing: {e}"),
+                        })?;
                 match next_special {
                     Some(m) => {
                         if allowed_special.contains(&text[m.start()..m.end()]) {
@@ -260,7 +285,10 @@ impl CoreBPE {
 
             // Okay, here we go, compare this logic to encode_ordinary
             for mat in regex.find_iter(&text[start..end]) {
-                let piece = mat.unwrap().as_str().as_bytes();
+                let mat = mat.map_err(|e| EncodeError {
+                    message: format!("Regex error while tokenizing: {e}"),
+                })?;
+                let piece = mat.as_str().as_bytes();
                 if let Some(token) = self.encoder.get(piece) {
                     last_piece_token_len = 1;
                     ret.push(*token);
@@ -286,7 +314,7 @@ impl CoreBPE {
 
         // last_piece_token_len is how many tokens came from the last regex split. This is used
         // for determining unstable tokens, since you can't merge across (stable) regex splits
-        (ret, last_piece_token_len)
+        Ok((ret, last_piece_token_len))
     }
 
     fn _increase_last_piece_token_len(
@@ -333,7 +361,7 @@ impl CoreBPE {
         text: &str,
         allowed_special: &HashSet<&str>,
     ) -> (Vec<Rank>, HashSet<Vec<Rank>>) {
-        let (tokens, last_piece_token_len) = self.encode(text, allowed_special);
+        let (tokens, last_piece_token_len) = self.encode(text, allowed_special).unwrap();
         if last_piece_token_len == 0 {
             // If last_piece_token_len is zero, the last token was a special token and we have
             // no unstable bytes
@@ -392,7 +420,7 @@ impl CoreBPE {
                     // So convert to UTF-8 and do regex splitting.
                     // E.g. with cl100k_base "  !" gets split to " " + " !",
                     // but byte_pair_encode("  !") != byte_pair_encode(" ")
-                    Ok(s) => self.encode_ordinary(s),
+                    Ok(s) => self.encode_ordinary(s).unwrap(),
 
                     // Technically, whether or not this arm is correct depends on whether there
                     // would be a regex split before the UTF-8 truncation point.
@@ -516,7 +544,7 @@ impl CoreBPE {
 
     pub fn encode_with_special_tokens(&self, text: &str) -> Vec<Rank> {
         let allowed_special = self.special_tokens();
-        self.encode(text, &allowed_special).0
+        self.encode(text, &allowed_special).unwrap().0
     }
 
     pub fn is_special_token(&self, token: Rank) -> bool {

--- a/src/wasm_module.rs
+++ b/src/wasm_module.rs
@@ -214,7 +214,12 @@ impl JsHarmonyEncoding {
             };
         let allowed_set: std::collections::HashSet<&str> =
             allowed_vec.iter().map(|s| s.as_str()).collect();
-        Ok(self.inner.tokenizer().encode(text, &allowed_set).0)
+        let (tokens, _) = self
+            .inner
+            .tokenizer()
+            .encode(text, &allowed_set)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        Ok(tokens)
     }
 
     #[wasm_bindgen(js_name = specialTokens)]

--- a/tests/test_harmony.py
+++ b/tests/test_harmony.py
@@ -896,6 +896,24 @@ def test_encode_allowed_special():
     ]
 
 
+def test_encode_pathological_input_raises_harmony_error():
+    # A very long run of the same character makes the underlying fancy-regex
+    # backtracking engine give up. This must be reported as a catchable
+    # HarmonyError instead of an uncatchable panic that crashes the host
+    # process (see issue #93).
+    encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+    text = "a" * 1_300_000
+
+    with pytest.raises(HarmonyError):
+        encoding.encode(text, allowed_special="all")
+
+    convo = Conversation.from_messages(
+        [Message.from_role_and_content(Role.USER, text)]
+    )
+    with pytest.raises(HarmonyError):
+        encoding.render_conversation_for_completion(convo, Role.ASSISTANT)
+
+
 def test_is_special_token():
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 


### PR DESCRIPTION
Tokenizing a very long run of a single character (for example a request body with roughly a million repeated dashes) makes the fancy-regex backtracking engine give up and return an error. `CoreBPE::encode` and `encode_ordinary` called `.unwrap()` on that result, so the failure surfaced as a Rust panic that aborted the host process. Through the Python bindings this became an uncatchable `PanicException`, which is what crashes servers like vLLM with a 500 in #93 rather than letting them handle the bad input. You can reproduce it with `load_harmony_encoding("HarmonyGptOss").encode("a" * 1_300_000)`, and the same panic also fires on the rendering path via `render_conversation_for_completion`.

This threads the regex error through `encode` and `encode_ordinary` as a new `EncodeError`, which mirrors how upstream tiktoken handles the exact same call sites. The error is then mapped to `HarmonyError` in the Python binding and to a `JsValue` in the wasm binding, so callers get a normal catchable exception. `encode_with_special_tokens` keeps its infallible signature because it is only ever called on short known special-token strings that cannot trigger the backtracking blow up, which keeps the change small. Ordinary encoding is byte for byte unchanged.

Added a Rust test asserting that `encode` and `encode_ordinary` return `Err` on the pathological input, and a Python test asserting that both `encode` and `render_conversation_for_completion` raise `HarmonyError` instead of crashing. `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test`, and `pytest` all pass.

Closes #93