### PR TITLE
perf: precompute start/message formatting token ids in StreamableParser

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1059,6 +1059,8 @@ pub struct StreamableParser {
     messages: Vec<Message>,
     state: StreamState,
     stop_tokens: HashSet<Rank>,
+    start_token: Rank,
+    message_token: Rank,
     last_content_delta: Option<String>,
     undecoded_tokens: Vec<Rank>,
     undecoded_bytes: Vec<u8>,
@@ -1090,6 +1092,8 @@ impl StreamableParser {
         options: ParseOptions,
     ) -> anyhow::Result<Self> {
         let stop_tokens = encoding.stop_tokens()?;
+        let start_token = encoding.render_formatting_token(FormattingToken::Start)?;
+        let message_token = encoding.render_formatting_token(FormattingToken::Message)?;
         let (state, next_role) = match role {
             Some(role) => (
                 StreamState::Header {
@@ -1106,6 +1110,8 @@ impl StreamableParser {
             messages: Vec::new(),
             state,
             stop_tokens,
+            start_token,
+            message_token,
             last_content_delta: None,
             undecoded_tokens: Vec::new(),
             undecoded_bytes: Vec::new(),
@@ -1123,9 +1129,7 @@ impl StreamableParser {
         let next_role_clone = self.next_role.clone();
         match &mut self.state {
             StreamState::ExpectStart => {
-                let start = self
-                    .encoding
-                    .render_formatting_token(FormattingToken::Start)?;
+                let start = self.start_token;
                 match token {
                     Some(token) if token == start => {
                         self.state = StreamState::Header {
@@ -1147,9 +1151,7 @@ impl StreamableParser {
                 }
             }
             StreamState::Header { header_tokens } => {
-                let msg_tok = self
-                    .encoding
-                    .render_formatting_token(FormattingToken::Message)?;
+                let msg_tok = self.message_token;
                 match token {
                     Some(token) if token == msg_tok => {
                         // Clone the tokens and next_role, then clear the state before parsing


### PR DESCRIPTION
While in the `ExpectStart` and `Header` states, `StreamableParser::process_next` calls `render_formatting_token` — a full `encode_with_special_tokens` — for `<|start|>` / `<|message|>` on **every input token**, just to compare the incoming token against it:

```rust
StreamState::ExpectStart => {
    let start = self.encoding.render_formatting_token(FormattingToken::Start)?; // per-token BPE encode
    ...
}
StreamState::Header { .. } => {
    let msg_tok = self.encoding.render_formatting_token(FormattingToken::Message)?; // per-token BPE encode
    ...
}
```

These ids are constant for the lifetime of the parser. `stop_tokens` is already precomputed once in `new_with_options` and the `Content` state compares against that cached set; the start/message ids should be handled the same way.

This PR precomputes both ids once in `new_with_options`, stores them on the parser, and compares against the cached `Rank` in the two hot states. Pure caching — no behavior change.

### Impact
On a long stream that stays in the header state, the per-token re-encode dominates. Benchmarking a 1,000,000-token stream (release build):

| | time |
|---|---|
| before | ~13.06 s |
| after | ~3.07 ms |

Besides the obvious speedup, it bounds CPU on malformed / very long model output that the streaming parser is fed directly.

### Testing
`cargo test` — all 30 tests pass unchanged (including the `streamable_parser*` tests).

---
_Disclosure: this change was prepared with AI assistance; the diff and benchmark were reviewed and run locally against `main`._