### PR TITLE
fix: parse constrained content type without recipient

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1323,6 +1323,18 @@ impl StreamableParser {
         Ok(self)
     }
 
+    fn is_constrained_content_type(&self, header_part: &str) -> bool {
+        let constrained_format_marker = self
+            .encoding
+            .mapped_format_token(FormattingToken::ConstrainedFormat);
+
+        if let Some(marker) = constrained_format_marker {
+            header_part.starts_with(marker)
+        } else {
+            false
+        }
+    }
+
     /// Helper to parse header metadata from a decoded string.
     /// Returns the parsed header and any remaining content after extracting header parts.
     ///
@@ -1420,12 +1432,11 @@ impl StreamableParser {
             if let Some(stripped) = last_part.strip_prefix("to=") {
                 // The header contains a recipient but *no* content-type.
                 recipient = Some(stripped.to_string());
-            } else if num_parts == 1 {
-                // Only one part total (after potential role removal) and it doesn't start
-                // with "to=" => interpret it as a standalone recipient.
+            } else if num_parts == 1 && !self.is_constrained_content_type(last_part) {
+                // A single unconstrained part is a standalone recipient.
                 recipient = Some(last_part.to_string());
             } else {
-                // More than one token and the last one is not a recipient -> treat as content-type.
+                // The last part is a content type, which may appear without a recipient.
                 content_type = Some(last_part.to_string());
 
                 // After removing the content-type there may be exactly one token describing the recipient.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -675,6 +675,26 @@ fn test_streamable_parser_tool_call_with_constrain_adjacent() {
 }
 
 #[test]
+fn test_streamable_parser_constrained_output_without_recipient() {
+    let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+    let text = concat!(
+        "<|start|>assistant<|channel|>final ",
+        "<|constrain|>json<|message|>{\"result\":true}<|return|>"
+    );
+    let tokens = encoding.tokenizer().encode_with_special_tokens(text);
+    let expected = Message::from_role_and_content(Role::Assistant, "{\"result\":true}")
+        .with_channel("final")
+        .with_content_type("<|constrain|>json");
+    let mut parser = StreamableParser::new(encoding, None).unwrap();
+
+    for token in tokens {
+        parser.process(token).unwrap();
+    }
+
+    assert_eq!(parser.messages(), &[expected]);
+}
+
+#[test]
 fn test_missing_message_token_requires_non_strict_mode() {
     let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
     let malformed = "<|channel|>commentary Hello<|end|>";

--- a/tests/test_harmony.py
+++ b/tests/test_harmony.py
@@ -983,6 +983,26 @@ def test_streamable_parser_tool_call_with_constrain_adjacent():
     assert parser.messages == expected
 
 
+def test_streamable_parser_constrained_output_without_recipient():
+    encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+    text = (
+        "<|start|>assistant<|channel|>final "
+        '<|constrain|>json<|message|>{"result":true}<|return|>'
+    )
+    tokens = encoding.encode(text, allowed_special="all")
+    expected = (
+        Message.from_role_and_content(Role.ASSISTANT, '{"result":true}')
+        .with_channel("final")
+        .with_content_type("<|constrain|>json")
+    )
+
+    parser = StreamableParser(encoding, None)
+    for token in tokens:
+        parser.process(token)
+
+    assert parser.messages == [expected]
+
+
 @pytest.mark.parametrize("strict, expect_error", [(False, False), (True, True)])
 def test_streamable_parser_missing_message_token(strict: bool, expect_error: bool):
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)


### PR DESCRIPTION
## Problem

`StreamableParser` treats the only remaining header part as a standalone recipient after removing the role and channel. This misparses constrained final output that has a content type but no recipient:

```text
<|start|>assistant<|channel|>final <|constrain|>json<|message|>{"result":true}<|return|>
```

The parser currently produces:

```text
recipient = Some("<|constrain|>json")
content_type = None
```

The expected result is:

```text
recipient = None
content_type = Some("<|constrain|>json")
```

This output shape was observed with gpt-oss-120b when a Harmony developer message defined a `# Response Formats` schema without a tool recipient.

## Fix

Recognize a standalone header part that starts with the current encoding's `<|constrain|>` marker as `content_type`. Existing parsing for `to=...` and ordinary standalone recipients is unchanged.

## Testing

Added equivalent Rust and Python regression tests that stream the token sequence through `StreamableParser` and verify the complete parsed message.

- `cargo fmt --all -- --check`
- `pytest` (43 passed)