### PR TITLE
Export RenderConversationConfig from crate root

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,19 @@ openai-harmony = { git = "https://github.com/openai/harmony" }
 
 ```rust
 use openai_harmony::chat::{Message, Role, Conversation};
-use openai_harmony::{HarmonyEncodingName, load_harmony_encoding};
+use openai_harmony::{
+    HarmonyEncodingName, RenderConversationConfig, load_harmony_encoding,
+};
 
 fn main() -> anyhow::Result<()> {
     let enc = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss)?;
     let convo =
         Conversation::from_messages([Message::from_role_and_content(Role::User, "Hello there!")]);
-    let tokens = enc.render_conversation_for_completion(&convo, Role::Assistant, None)?;
+    let config = RenderConversationConfig {
+        auto_drop_analysis: false,
+    };
+    let tokens =
+        enc.render_conversation_for_completion(&convo, Role::Assistant, Some(&config))?;
     println!("{:?}", tokens);
     Ok(())
 }

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -13,7 +13,7 @@ openai-harmony = { git = "https://github.com/openai/harmony" }
 and import the items you need:
 
 ```rust
-use openai_harmony::{load_harmony_encoding, HarmonyEncodingName};
+use openai_harmony::{load_harmony_encoding, HarmonyEncodingName, RenderConversationConfig};
 use openai_harmony::chat::{Message, Role, Conversation};
 ```
 
@@ -93,6 +93,10 @@ Important methods:
 - `stop_tokens()` and `stop_tokens_for_assistant_actions()` – sets of stop tokens for sampling.
 
 `ParseOptions` currently exposes a single field, `strict`, which defaults to `true`. Set it to `false` when you need to recover from malformed model output in downstream systems.
+
+### `RenderConversationConfig`
+
+Controls conversation rendering. It defaults to `auto_drop_analysis: true`; set the field to `false` and pass `Some(&config)` to a conversation rendering method to preserve analysis content.
 
 ### `StreamableParser`
 

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -96,7 +96,7 @@ Important methods:
 
 ### `RenderConversationConfig`
 
-Controls conversation rendering. It defaults to `auto_drop_analysis: true`; set the field to `false` and pass `Some(&config)` to a conversation rendering method to preserve analysis content.
+Controls conversation rendering. Passing `None` preserves analysis content. To drop eligible prior analysis, pass `Some(&RenderConversationConfig::default())`; its `auto_drop_analysis` field defaults to `true`. Set the field to `false` to preserve analysis when passing a config explicitly.
 
 ### `StreamableParser`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod registry;
 mod tiktoken;
 pub mod tiktoken_ext;
 
-pub use encoding::{HarmonyEncoding, ParseOptions, StreamableParser};
+pub use encoding::{HarmonyEncoding, ParseOptions, RenderConversationConfig, StreamableParser};
 pub use registry::load_harmony_encoding;
 pub use registry::HarmonyEncodingName;
 


### PR DESCRIPTION
## Summary
- re-export `RenderConversationConfig` from the crate root
- show how Rust callers can customize `auto_drop_analysis`
- document the rendering configuration in the Rust API guide

## Tests
- `cargo fmt --check`
- `cargo test --doc`
- `cargo test --all-targets --all-features` (30 passed)
- `pytest` (42 passed)

Closes #73